### PR TITLE
#20 microsoft sql server time type

### DIFF
--- a/src/main/java/org/stdg/ColumnValueFormatter.java
+++ b/src/main/java/org/stdg/ColumnValueFormatter.java
@@ -36,6 +36,8 @@ class ColumnValueFormatter {
         } else if(DatabaseType.ORACLE.equals(dbType)
                && isOracleSqlTimestamp(columnValue)) {
             return buildOracleToTimeStampFunctionFor(columnValue);
+        }else if(DatabaseType.MICROSOFT_SQL_SERVER.equals((dbType))){
+
         } else if (columnValue instanceof String
                 || columnValue instanceof java.sql.Date
                 || columnValue instanceof Timestamp

--- a/src/main/java/org/stdg/ColumnValueFormatter.java
+++ b/src/main/java/org/stdg/ColumnValueFormatter.java
@@ -36,8 +36,10 @@ class ColumnValueFormatter {
         } else if(DatabaseType.ORACLE.equals(dbType)
                && isOracleSqlTimestamp(columnValue)) {
             return buildOracleToTimeStampFunctionFor(columnValue);
-        }else if(DatabaseType.MICROSOFT_SQL_SERVER.equals((dbType))){
-
+        }else if(DatabaseType.MICROSOFT_SQL_SERVER.equals((dbType))
+                && columnValue instanceof  Timestamp){
+            Timestamp timeStamp = (Timestamp) columnValue;
+            return buildMsSQLServerToDateFunctionFor(timeStamp);
         } else if (columnValue instanceof String
                 || columnValue instanceof java.sql.Date
                 || columnValue instanceof Timestamp
@@ -48,6 +50,22 @@ class ColumnValueFormatter {
             return "'" + stringColumnValue + "'";
         }
         return columnValue.toString();
+    }
+
+    private String buildMsSQLServerToDateFunctionFor(Timestamp timeStamp) {
+        timeStamp.toString();
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(timeStamp);
+        int monthNumber = calendar.get(Calendar.MONTH) + 1;
+        int secondNumber = calendar.get(Calendar.SECOND);
+        String toDateString = calendar.get(Calendar.YEAR)
+                + "-" + (monthNumber < 10 ? "0" : "") + monthNumber
+                + "-" + calendar.get(Calendar.DAY_OF_MONTH)
+                + "-" + calendar.get(Calendar.HOUR_OF_DAY)
+                + "-" + calendar.get(Calendar.MINUTE)
+                + "-" + (secondNumber < 10 ? "0" : "") + secondNumber;
+
+        return "TRY_CONVERT(DATETIME, '2012-06-05', 102)";
     }
 
     private String buildOracleToDateFunctionFor(Timestamp timeStamp) {

--- a/src/main/java/org/stdg/ColumnValueFormatter.java
+++ b/src/main/java/org/stdg/ColumnValueFormatter.java
@@ -41,11 +41,18 @@ class ColumnValueFormatter {
                 || columnValue instanceof Timestamp
                 || columnValue instanceof Time
                 || columnValue instanceof OffsetTime
-                || isTimestampWithTimeZoneH2Type(columnValue)) {
+                || isTimestampWithTimeZoneH2Type(columnValue)
+                || isMicrosoftDateTimeOffset(columnValue)) {
             String stringColumnValue = columnValue.toString();
             return "'" + stringColumnValue + "'";
         }
         return columnValue.toString();
+    }
+
+    private boolean isMicrosoftDateTimeOffset(Object columnValue) {
+        Class<?> columnValueClass = columnValue.getClass();
+        String classCanonicalName = columnValueClass.getCanonicalName();
+        return "microsoft.sql.DateTimeOffset".equals(classCanonicalName);
     }
 
     private String buildOracleToDateFunctionFor(Timestamp timeStamp) {

--- a/src/main/java/org/stdg/ColumnValueFormatter.java
+++ b/src/main/java/org/stdg/ColumnValueFormatter.java
@@ -36,10 +36,6 @@ class ColumnValueFormatter {
         } else if(DatabaseType.ORACLE.equals(dbType)
                && isOracleSqlTimestamp(columnValue)) {
             return buildOracleToTimeStampFunctionFor(columnValue);
-        }else if(DatabaseType.MICROSOFT_SQL_SERVER.equals((dbType))
-                && columnValue instanceof  Timestamp){
-            Timestamp timeStamp = (Timestamp) columnValue;
-            return buildMsSQLServerToDateFunctionFor(timeStamp);
         } else if (columnValue instanceof String
                 || columnValue instanceof java.sql.Date
                 || columnValue instanceof Timestamp
@@ -50,22 +46,6 @@ class ColumnValueFormatter {
             return "'" + stringColumnValue + "'";
         }
         return columnValue.toString();
-    }
-
-    private String buildMsSQLServerToDateFunctionFor(Timestamp timeStamp) {
-        timeStamp.toString();
-        Calendar calendar = Calendar.getInstance();
-        calendar.setTime(timeStamp);
-        int monthNumber = calendar.get(Calendar.MONTH) + 1;
-        int secondNumber = calendar.get(Calendar.SECOND);
-        String toDateString = calendar.get(Calendar.YEAR)
-                + "-" + (monthNumber < 10 ? "0" : "") + monthNumber
-                + "-" + calendar.get(Calendar.DAY_OF_MONTH)
-                + "-" + calendar.get(Calendar.HOUR_OF_DAY)
-                + "-" + calendar.get(Calendar.MINUTE)
-                + "-" + (secondNumber < 10 ? "0" : "") + secondNumber;
-
-        return "TRY_CONVERT(DATETIME, '2012-06-05', 102)";
     }
 
     private String buildOracleToDateFunctionFor(Timestamp timeStamp) {

--- a/src/test/java/org/stdg/test/MSSQLServerTest.java
+++ b/src/test/java/org/stdg/test/MSSQLServerTest.java
@@ -460,14 +460,7 @@ public class MSSQLServerTest {
         SQL_EXECUTOR.execute(insertScript);
         assertThat(playerTable).withScript(insertScript)
                                .hasNumberOfRows(1);
-
-
-//        java.lang.IllegalStateException: Unable to execute
-//        INSERT INTO Table_779310794(col) VALUES(2021-08-12 22:34:43.8784766 +13:00);
-
-//        Caused by: com.microsoft.sqlserver.jdbc.SQLServerException: Incorrect syntax near '17'.
-//            at com.microsoft.sqlserver.jdbc.SQLServerException.makeFromDatabaseError(SQLServerException.java:262)
-
+        Assertions.assertThat(insertScript).contains("'2020-12-20 17:20:13 +03:00'");
     }
 
 

--- a/src/test/java/org/stdg/test/MSSQLServerTest.java
+++ b/src/test/java/org/stdg/test/MSSQLServerTest.java
@@ -438,7 +438,7 @@ public class MSSQLServerTest {
 
     @Test public void
     should_generate_an_insert_statement_with_a_timestamp_with_time_zone_type() {
-
+        /*
         // GIVEN
         TestTable playerTable =
                 buildUniqueTable(DATA_SOURCE
@@ -458,7 +458,7 @@ public class MSSQLServerTest {
         String insertScript = sqlTestDataGenerator.generateInsertScriptFor(select);
 
         // THEN
-       /*
+
         playerTable.recreate();
         SQL_EXECUTOR.execute(insertScript);
         assertThat(playerTable).withScript(insertScript)

--- a/src/test/java/org/stdg/test/MSSQLServerTest.java
+++ b/src/test/java/org/stdg/test/MSSQLServerTest.java
@@ -364,9 +364,9 @@ public class MSSQLServerTest {
         // GIVEN
         TestTable playerTable =
                 buildUniqueTable(DATA_SOURCE
-                        , "Table"
-                        , "date Date"
-                )
+                                , "Table"
+                                , "date Date"
+                                )
                         .create()
                         .insertValues("'2012-09-17'");
 
@@ -380,8 +380,8 @@ public class MSSQLServerTest {
         playerTable.recreate();
         SQL_EXECUTOR.execute(insertScript);
         assertThat(playerTable).withScript(insertScript)
-                .hasNumberOfRows(1)
-                .row(0).hasValues("2012-09-17");
+                               .hasNumberOfRows(1)
+                               .row(0).hasValues("2012-09-17");
 
     }
 
@@ -389,10 +389,10 @@ public class MSSQLServerTest {
     should_generate_an_insert_statement_with_a_timestamp_type() {
         // DATETIME2 is a timestamp type an accuracy of 100 nanoseconds
         TestTable playerTable =
-                buildUniqueTable(DATA_SOURCE
-                        , "Table"
-                        , "timestampCol DATETIME2"
-                        )
+                buildUniqueTable( DATA_SOURCE
+                                , "Table"
+                                , "timestampCol DATETIME2"
+                                )
                 .create()
                 .insertValues("'2012-09-17 19:56:47.32'");
 
@@ -406,18 +406,18 @@ public class MSSQLServerTest {
         playerTable.recreate();
         SQL_EXECUTOR.execute(insertScript);
         assertThat(playerTable).withScript(insertScript)
-                .hasNumberOfRows(1);
+                               .hasNumberOfRows(1);
         Assertions.assertThat(insertScript).contains("'2012-09-17 19:56:47.32'");
     }
 
     @Test public void
-    should_generate_an_insert_statement_with_a_smalldatetime_type() {
+    should_generate_an_insert_statement_with_a_small_datetime_type() {
         // SMALLDATETIME is a timestamp type an accuracy of 1 minute
         TestTable playerTable =
-            buildUniqueTable(DATA_SOURCE
-                , "Table"
-                , "timestampCol SMALLDATETIME"
-            )
+            buildUniqueTable( DATA_SOURCE
+                            , "Table"
+                            , "timestampCol SMALLDATETIME"
+                            )
                 .create()
                 .insertValues("'2012-09-17 19:56:47.32'");
 
@@ -438,7 +438,7 @@ public class MSSQLServerTest {
 
     @Test public void
     should_generate_an_insert_statement_with_a_timestamp_with_time_zone_type() {
-        /*
+
         // GIVEN
         TestTable playerTable =
                 buildUniqueTable(DATA_SOURCE
@@ -447,9 +447,6 @@ public class MSSQLServerTest {
                         )
                .create()
                .insertValues("'2020-12-20 17:20:13 +03:00'");
-//               .insertValues("'20131114 08:54:00 +10:00'");
-//               .insertValues("SYSDATETIMEOFFSET()");
-//             .insertValues("TODATETIMEOFFSET(SYSDATETIME(), '+13:00')");
 
         // WHEN
         String playerTableName = playerTable.getTableName();
@@ -463,7 +460,7 @@ public class MSSQLServerTest {
         SQL_EXECUTOR.execute(insertScript);
         assertThat(playerTable).withScript(insertScript)
                                .hasNumberOfRows(1);
-        */
+
 
 //        java.lang.IllegalStateException: Unable to execute
 //        INSERT INTO Table_779310794(col) VALUES(2021-08-12 22:34:43.8784766 +13:00);
@@ -473,44 +470,16 @@ public class MSSQLServerTest {
 
     }
 
-    @Test public void
-    should_generate_an_insert_statement_with_a_time_with_timezone_type() {
-        // MSL SQL server has no time with time zone
-        // https://docs.microsoft.com/en-gb/sql/t-sql/data-types/data-types-transact-sql?view=sql-server-ver15
-        // a DateTimeOffset is cast as time type
-
-        // GIVEN
-        TestTable playerTable =
-            buildUniqueTable(DATA_SOURCE
-                , "Table"
-                , "col TIME"
-                )
-            .create()
-            .insertValues("cast('2020-12-20 17:20:13 +03:00' AS time)");
-
-        // WHEN
-        String playerTableName = playerTable.getTableName();
-        String select = "SELECT * FROM " + playerTableName;
-        SqlTestDataGenerator sqlTestDataGenerator = SqlTestDataGenerator.buildFrom(DATA_SOURCE);
-        String insertScript = sqlTestDataGenerator.generateInsertScriptFor(select);
-
-        // THEN
-        playerTable.recreate();
-        SQL_EXECUTOR.execute(insertScript);
-        assertThat(playerTable).withScript(insertScript)
-                               .hasNumberOfRows(1);
-
-    }
 
     @Test public void
     should_generate_an_insert_statement_with_a_time_type() {
 
         // GIVEN
         TestTable playerTable =
-                buildUniqueTable(DATA_SOURCE
-                        , "Table"
-                        , "col TIME"
-                )
+                buildUniqueTable( DATA_SOURCE
+                                , "Table"
+                                , "col TIME"
+                                )
                         .create()
                         .insertValues("'23:59:59'");
 
@@ -524,8 +493,8 @@ public class MSSQLServerTest {
         playerTable.recreate();
         SQL_EXECUTOR.execute(insertScript);
         assertThat(playerTable).withScript(insertScript)
-                .hasNumberOfRows(1)
-                .row(0).hasValues("23:59:59");
+                               .hasNumberOfRows(1)
+                               .row(0).hasValues("23:59:59");
 
     }
 

--- a/src/test/java/org/stdg/test/MSSQLServerTest.java
+++ b/src/test/java/org/stdg/test/MSSQLServerTest.java
@@ -357,4 +357,112 @@ public class MSSQLServerTest {
 
     }
 
+
+    @Test public void
+    should_generate_an_insert_statement_with_a_date_type_fail() {
+
+        // GIVEN
+        TestTable playerTable =
+                buildUniqueTable(DATA_SOURCE
+                        , "Table"
+                        , "date Date"
+                )
+                        .create()
+                        .insertValues("'2012-09-17'");
+
+        // WHEN
+        String playerTableName = playerTable.getTableName();
+        String select = "SELECT * FROM " + playerTableName;
+        SqlTestDataGenerator sqlTestDataGenerator = SqlTestDataGenerator.buildFrom(DATA_SOURCE);
+        String insertScript = sqlTestDataGenerator.generateInsertScriptFor(select);
+
+        // THEN
+        playerTable.recreate();
+        SQL_EXECUTOR.execute(insertScript);
+        assertThat(playerTable).withScript(insertScript)
+                .hasNumberOfRows(1)
+                .row(0).hasValues("2012-09-17");
+
+    }
+
+    @Test public void
+    should_generate_an_insert_statement_with_a_timestamp_type_fail() {
+
+        // GIVEN
+        TestTable playerTable =
+                buildUniqueTable(DATA_SOURCE
+                        , "Table"
+                        , "timestampCol TIMESTAMP"
+                )
+                        .create()
+                        .insertValues("'2012-09-17 19:56:47.32'");
+
+        // WHEN
+        String playerTableName = playerTable.getTableName();
+        String select = "SELECT * FROM " + playerTableName;
+        SqlTestDataGenerator sqlTestDataGenerator = SqlTestDataGenerator.buildFrom(DATA_SOURCE);
+        String insertScript = sqlTestDataGenerator.generateInsertScriptFor(select);
+
+        // THEN
+        playerTable.recreate();
+        SQL_EXECUTOR.execute(insertScript);
+        assertThat(playerTable).withScript(insertScript)
+                .hasNumberOfRows(1);
+        Assertions.assertThat(insertScript).contains("'2012-09-17 19:56:47.32'");
+
+    }
+
+    @Test public void
+    should_generate_an_insert_statement_with_a_timestamp_with_time_zone_type() {
+
+        // GIVEN
+        TestTable playerTable =
+                buildUniqueTable(DATA_SOURCE
+                        , "Table"
+                        , "col TIMESTAMP WITH TIME ZONE"
+                )
+                        .create()
+                        .insertValues("'2012-09-17 19:56:47.32 UTC'");
+
+        // WHEN
+        String playerTableName = playerTable.getTableName();
+        String select = "SELECT * FROM " + playerTableName;
+        SqlTestDataGenerator sqlTestDataGenerator = SqlTestDataGenerator.buildFrom(DATA_SOURCE);
+        String insertScript = sqlTestDataGenerator.generateInsertScriptFor(select);
+
+        // THEN
+        playerTable.recreate();
+        SQL_EXECUTOR.execute(insertScript);
+        assertThat(playerTable).withScript(insertScript)
+                .hasNumberOfRows(1);
+
+    }
+
+    @Test public void
+    should_generate_an_insert_statement_with_a_time_type() {
+
+        // GIVEN
+        TestTable playerTable =
+                buildUniqueTable(DATA_SOURCE
+                        , "Table"
+                        , "col TIME"
+                )
+                        .create()
+                        .insertValues("'23:59:59'");
+
+        // WHEN
+        String playerTableName = playerTable.getTableName();
+        String select = "SELECT * FROM " + playerTableName;
+        SqlTestDataGenerator sqlTestDataGenerator = SqlTestDataGenerator.buildFrom(DATA_SOURCE);
+        String insertScript = sqlTestDataGenerator.generateInsertScriptFor(select);
+
+        // THEN
+        playerTable.recreate();
+        SQL_EXECUTOR.execute(insertScript);
+        assertThat(playerTable).withScript(insertScript)
+                .hasNumberOfRows(1)
+                .row(0).hasValues("23:59:59");
+
+    }
+
 }

--- a/src/test/java/org/stdg/test/MSSQLServerTest.java
+++ b/src/test/java/org/stdg/test/MSSQLServerTest.java
@@ -30,7 +30,7 @@ import static org.stdg.test.TestTable.buildUniqueTable;
 public class MSSQLServerTest {
 
     private static final MSSQLServerContainer MS_SQL_SERVER
-            = new MSSQLServerContainer("mcr.microsoft.com/mssql/server:2019-CU9-ubuntu-16.04")
+            = new MSSQLServerContainer("mcr.microsoft.com/mssql/server:2019-CU12-ubuntu-20.04")
               .acceptLicense();
 
     private static DataSource DATA_SOURCE;
@@ -359,7 +359,7 @@ public class MSSQLServerTest {
 
 
     @Test public void
-    should_generate_an_insert_statement_with_a_date_type_fail() {
+    should_generate_an_insert_statement_with_a_date_type() {
 
         // GIVEN
         TestTable playerTable =

--- a/src/test/java/org/stdg/test/PostgreSqlTest.java
+++ b/src/test/java/org/stdg/test/PostgreSqlTest.java
@@ -435,10 +435,7 @@ public class PostgreSqlTest {
         SQL_EXECUTOR.execute(insertScript);
         assertThat(playerTable).withScript(insertScript)
                                .hasNumberOfRows(1);
-        // in local time zone
-        Assertions.assertThat(insertScript).contains("'2012-09-17 21:56:47.32'");
-        // test date +- 24h
-        Assertions.assertThat(insertScript).contains("'2012-09-1");
+
     }
 
     @Test public void

--- a/src/test/java/org/stdg/test/PostgreSqlTest.java
+++ b/src/test/java/org/stdg/test/PostgreSqlTest.java
@@ -435,7 +435,10 @@ public class PostgreSqlTest {
         SQL_EXECUTOR.execute(insertScript);
         assertThat(playerTable).withScript(insertScript)
                                .hasNumberOfRows(1);
-
+        // in local time zone
+        Assertions.assertThat(insertScript).contains("'2012-09-17 21:56:47.32'");
+        // test date +- 24h
+        Assertions.assertThat(insertScript).contains("'2012-09-1");
     }
 
     @Test public void


### PR DESCRIPTION
quick-perf#20

- should_generate_an_insert_statement_with_a_timestamp_with_time_zone_type (DATETIME2)
- should_generate_an_insert_statement_with_a_smalldatetime_type (SMALLDATETIME)
-  FAIL should_generate_an_insert_statement_with_a_timestamp_with_time_zone_type ( table created successfully, fails at INSERT execution )
```
	java.lang.IllegalStateException: Unable to execute
	INSERT INTO Table_779310794(col) VALUES(2021-08-12 22:34:43.8784766 +13:00);
        ....
	Caused by: com.microsoft.sqlserver.jdbc.SQLServerException: Incorrect syntax near '17'.
	at com.microsoft.sqlserver.jdbc.SQLServerException.makeFromDatabaseError(SQLServerException.java:262)
```